### PR TITLE
Toggle Rework / iOS 16.0+ Fix

### DIFF
--- a/DebugMenu/DebugMenu/Actions/DebugAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugAction.swift
@@ -7,6 +7,4 @@
 
 import SwiftUI
 
-public protocol DebugAction {
-    var asAnyView: AnyView { get }
-}
+public protocol DebugAction {}

--- a/DebugMenu/DebugMenu/Actions/DebugAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugAction.swift
@@ -5,6 +5,12 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import Foundation
+import SwiftUI
 
 public protocol DebugAction {}
+
+//For use with Actions that utilize generics where type cannot be inferred at view resolution time &
+//For Any consumers that want to define custom actions
+public protocol DebugCustomAction: DebugAction {
+    var rowView: AnyView { get }
+}

--- a/DebugMenu/DebugMenu/Actions/DebugAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugAction.swift
@@ -5,6 +5,6 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import SwiftUI
+import Foundation
 
 public protocol DebugAction {}

--- a/DebugMenu/DebugMenu/Actions/DebugButtonAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugButtonAction.swift
@@ -5,8 +5,6 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import Foundation
-
 public struct DebugButtonAction: DebugAction {
     let title: String
     let action: () -> Void

--- a/DebugMenu/DebugMenu/Actions/DebugButtonAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugButtonAction.swift
@@ -10,11 +10,7 @@ import SwiftUI
 public struct DebugButtonAction: DebugAction {
     let title: String
     let action: () -> Void
-
-    public var asAnyView: AnyView {
-        AnyView(DebugButtonRow(action: self))
-    }
-
+    
     public init(title: String, action: @escaping () -> Void) {
         self.title = title
         self.action = action

--- a/DebugMenu/DebugMenu/Actions/DebugButtonAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugButtonAction.swift
@@ -5,7 +5,7 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import SwiftUI
+import Foundation
 
 public struct DebugButtonAction: DebugAction {
     let title: String

--- a/DebugMenu/DebugMenu/Actions/DebugHostControllerAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugHostControllerAction.swift
@@ -11,10 +11,6 @@ public struct DebugHostControllerAction: DebugAction {
     let title: String
     let action: (UIHostingController<AnyView>) -> Void
 
-    public var asAnyView: AnyView {
-        AnyView(DebugHostControllerRow(action: self))
-    }
-
     public init(title: String, action: @escaping (UIHostingController<AnyView>) -> Void) {
         self.title = title
         self.action = action

--- a/DebugMenu/DebugMenu/Actions/DebugNavigationAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugNavigationAction.swift
@@ -1,0 +1,22 @@
+//
+//  DebugNavigationAction.swift
+//  
+//
+//  Created by Alejandro Zielinsky on 2022-10-31.
+//
+
+import SwiftUI
+
+public struct DebugNavigationAction<Destination: View>: DebugCustomAction {
+    let title: String
+    let destination: Destination
+
+    public var rowView: AnyView {
+        AnyView(DebugNavigationRow(action: self))
+    }
+
+    public init(title: String, @ViewBuilder destination: () -> Destination) {
+        self.title = title
+        self.destination = destination()
+    }
+}

--- a/DebugMenu/DebugMenu/Actions/DebugSubmenuAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugSubmenuAction.swift
@@ -11,10 +11,6 @@ public struct DebugSubmenuAction: DebugAction {
     let title: String
     let dataSource: BaseDebugDataSource
 
-    public var asAnyView: AnyView {
-        AnyView(DebugSubmenuButtonRow(action: self))
-    }
-
     public init(title: String, dataSource: BaseDebugDataSource) {
         self.title = title
         self.dataSource = dataSource

--- a/DebugMenu/DebugMenu/Actions/DebugSubmenuAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugSubmenuAction.swift
@@ -5,7 +5,7 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import SwiftUI
+import Foundation
 
 public struct DebugSubmenuAction: DebugAction {
     let title: String

--- a/DebugMenu/DebugMenu/Actions/DebugSubmenuAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugSubmenuAction.swift
@@ -5,8 +5,6 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import Foundation
-
 public struct DebugSubmenuAction: DebugAction {
     let title: String
     let dataSource: BaseDebugDataSource

--- a/DebugMenu/DebugMenu/Actions/DebugTextFieldAlertAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugTextFieldAlertAction.swift
@@ -5,8 +5,6 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import Foundation
-
 public struct DebugTextFieldAlertAction: DebugAction {
     let title: String
     let alert: DebugTextFieldAlert

--- a/DebugMenu/DebugMenu/Actions/DebugTextFieldAlertAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugTextFieldAlertAction.swift
@@ -11,10 +11,6 @@ public struct DebugTextFieldAlertAction: DebugAction {
     let title: String
     let alert: DebugTextFieldAlert
 
-    public var asAnyView: AnyView {
-        AnyView(DebugTextFieldAlertRow(action: self))
-    }
-
     public init(title: String, alert: DebugTextFieldAlert) {
         self.title = title
         self.alert = alert

--- a/DebugMenu/DebugMenu/Actions/DebugTextFieldAlertAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugTextFieldAlertAction.swift
@@ -5,7 +5,7 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import SwiftUI
+import Foundation
 
 public struct DebugTextFieldAlertAction: DebugAction {
     let title: String

--- a/DebugMenu/DebugMenu/Actions/DebugToggleAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugToggleAction.swift
@@ -11,20 +11,18 @@ import Combine
 public struct DebugToggleAction: DebugAction, DebugResettable {
 
     let displayTitle: String
-    let toggle: Binding<Bool>
+    @Binding var toggle: Bool
     public private(set) var defaultValue: Bool
+    public var publisher: PassthroughSubject<Bool, Never>
 
-    public var asAnyView: AnyView {
-        AnyView(DebugToggleRow(action: self))
-    }
-
-    public init(title: String, toggle: Binding<Bool>) {
+    public init(title: String, toggle: Binding<Bool>, defaultValue: Bool, publisher: PassthroughSubject<Bool, Never>) {
         self.displayTitle = title
-        self.toggle = toggle
-        self.defaultValue = toggle.wrappedValue
+        self._toggle = toggle
+        self.defaultValue = defaultValue
+        self.publisher = publisher
     }
 
     public func resetToDefault() {
-        toggle.wrappedValue = defaultValue
+        $toggle.wrappedValue = defaultValue
     }
 }

--- a/DebugMenu/DebugMenu/BaseDebugDataSource.swift
+++ b/DebugMenu/DebugMenu/BaseDebugDataSource.swift
@@ -11,6 +11,8 @@ open class BaseDebugDataSource: DebugMenuDataSource {
 
     @Published public var debugAlert: DebugAlert?
 
+    @Published public var isLoading: Bool = false
+
     public init(sections: [DebugSection] = []) {
         self.sections = sections
     }

--- a/DebugMenu/DebugMenu/DebugMenuDataSource.swift
+++ b/DebugMenu/DebugMenu/DebugMenuDataSource.swift
@@ -15,6 +15,7 @@ public protocol DebugMenuDataSource: ObservableObject {
     func resetToDefaults()
     var includeCommonOptions: Bool { get }
     var debugAlert: DebugAlert? { get set }
+    var isLoading: Bool { get set }
 }
 
 extension DebugMenuDataSource {

--- a/DebugMenu/DebugMenu/DebugResettable.swift
+++ b/DebugMenu/DebugMenu/DebugResettable.swift
@@ -5,8 +5,6 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import Foundation
-
 public protocol DebugResettable {
     var defaultValue: Bool { get }
     func resetToDefault()

--- a/DebugMenu/DebugMenu/Models/DebugMenuAccessConfig.swift
+++ b/DebugMenu/DebugMenu/Models/DebugMenuAccessConfig.swift
@@ -5,8 +5,6 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import Foundation
-
 public struct DebugMenuAccessConfig {
     public var passwordSHA256: String
     public var longPressDuration: Double

--- a/DebugMenu/DebugMenu/Models/DebugTextFieldAlert.swift
+++ b/DebugMenu/DebugMenu/Models/DebugTextFieldAlert.swift
@@ -5,7 +5,6 @@
 //  Created by Alejandro Zielinsky on 2022-03-10.
 //
 
-import Foundation
 import UIKit
 
 public struct DebugTextFieldAlert {

--- a/DebugMenu/DebugMenu/Modifiers/DebugPasswordEntry.swift
+++ b/DebugMenu/DebugMenu/Modifiers/DebugPasswordEntry.swift
@@ -14,23 +14,23 @@ struct DebugPasswordEntry: ViewModifier {
     private let longPressDuration: CGFloat
     private let passwordHash: String
     @State private var showDialog = false
-    private var isVisible: Binding<Bool>
-    private let forceShow: Binding<Bool>?
+    @Binding var isVisible: Bool
+    @Binding var forceShow: Bool
 
     init(config: DebugMenuAccessConfig,
          isVisible: Binding<Bool>,
-         forceShow: Binding<Bool>? = nil) {
+         forceShow: Binding<Bool>) {
         self.passwordHash = config.passwordSHA256
         self.longPressDuration = config.longPressDuration
-        self.isVisible = isVisible
-        self.forceShow = forceShow
+        self._isVisible = isVisible
+        self._forceShow = forceShow
     }
 
     func body(content: Content) -> some View {
         content
             .onLongPressGesture(minimumDuration: longPressDuration) {
-                if let forceShow = forceShow?.wrappedValue, forceShow == true {
-                    isVisible.wrappedValue = true
+                if forceShow == true {
+                    $isVisible.wrappedValue = true
                 } else {
                     showDialog = true
                 }
@@ -46,8 +46,8 @@ struct DebugPasswordEntry: ViewModifier {
         guard let input = input else { return }
         if input.sha256 == self.passwordHash {
             showDialog = false
-            isVisible.wrappedValue = true
-            forceShow?.wrappedValue = true
+            $isVisible.wrappedValue = true
+            $forceShow.wrappedValue = true
         } else {
             showDialog = false
         }
@@ -57,7 +57,7 @@ struct DebugPasswordEntry: ViewModifier {
 public extension View {
     func debugMenuToggle(config: DebugMenuAccessConfig,
                          isVisible: Binding<Bool>,
-                         forceShow: Binding<Bool>? = nil) -> some View {
+                         forceShow: Binding<Bool>) -> some View {
         modifier(DebugPasswordEntry(
             config: config,
             isVisible: isVisible,

--- a/DebugMenu/DebugMenu/Modifiers/DebugPasswordEntry.swift
+++ b/DebugMenu/DebugMenu/Modifiers/DebugPasswordEntry.swift
@@ -11,20 +11,17 @@ import CommonCrypto
 
 struct DebugPasswordEntry: ViewModifier {
 
-    private let debugDataSource: BaseDebugDataSource
     private let longPressDuration: CGFloat
     private let passwordHash: String
     @State private var showDialog = false
     private var isVisible: Binding<Bool>
     private let forceShow: Binding<Bool>?
 
-    init(dataSource: BaseDebugDataSource,
-         config: DebugMenuAccessConfig,
+    init(config: DebugMenuAccessConfig,
          isVisible: Binding<Bool>,
          forceShow: Binding<Bool>? = nil) {
         self.passwordHash = config.passwordSHA256
         self.longPressDuration = config.longPressDuration
-        self.debugDataSource = dataSource
         self.isVisible = isVisible
         self.forceShow = forceShow
     }
@@ -58,12 +55,10 @@ struct DebugPasswordEntry: ViewModifier {
 }
 
 public extension View {
-    func debugMenuToggle(dataSource: BaseDebugDataSource,
-                         config: DebugMenuAccessConfig,
+    func debugMenuToggle(config: DebugMenuAccessConfig,
                          isVisible: Binding<Bool>,
                          forceShow: Binding<Bool>? = nil) -> some View {
         modifier(DebugPasswordEntry(
-            dataSource: dataSource,
             config: config,
             isVisible: isVisible,
             forceShow: forceShow

--- a/DebugMenu/DebugMenu/Modifiers/DebugPasswordEntry.swift
+++ b/DebugMenu/DebugMenu/Modifiers/DebugPasswordEntry.swift
@@ -5,7 +5,6 @@
 //  Created by Alejandro Zielinsky on 2021-12-06.
 //
 
-import Foundation
 import SwiftUI
 import CommonCrypto
 

--- a/DebugMenu/DebugMenu/Modifiers/DebugPasswordEntry.swift
+++ b/DebugMenu/DebugMenu/Modifiers/DebugPasswordEntry.swift
@@ -30,7 +30,7 @@ struct DebugPasswordEntry: ViewModifier {
         content
             .onLongPressGesture(minimumDuration: longPressDuration) {
                 if forceShow == true {
-                    $isVisible.wrappedValue = true
+                    isVisible = true
                 } else {
                     showDialog = true
                 }
@@ -46,8 +46,8 @@ struct DebugPasswordEntry: ViewModifier {
         guard let input = input else { return }
         if input.sha256 == self.passwordHash {
             showDialog = false
-            $isVisible.wrappedValue = true
-            $forceShow.wrappedValue = true
+            isVisible = true
+            forceShow = true
         } else {
             showDialog = false
         }
@@ -55,9 +55,11 @@ struct DebugPasswordEntry: ViewModifier {
 }
 
 public extension View {
-    func debugMenuToggle(config: DebugMenuAccessConfig,
-                         isVisible: Binding<Bool>,
-                         forceShow: Binding<Bool>) -> some View {
+    func debugMenuToggle(
+        config: DebugMenuAccessConfig,
+        isVisible: Binding<Bool>,
+        forceShow: Binding<Bool>
+    ) -> some View {
         modifier(DebugPasswordEntry(
             config: config,
             isVisible: isVisible,

--- a/DebugMenu/DebugMenu/Modifiers/LoadingIndicatorModifier.swift
+++ b/DebugMenu/DebugMenu/Modifiers/LoadingIndicatorModifier.swift
@@ -5,7 +5,7 @@
 //  Created by Alejandro Zielinsky on 2022-11-01.
 //
 
-import Foundation
+import SwiftUI
 
 struct LoadingIndicatorModifier: ViewModifier {
     let isLoading: Bool

--- a/DebugMenu/DebugMenu/Modifiers/LoadingIndicatorModifier.swift
+++ b/DebugMenu/DebugMenu/Modifiers/LoadingIndicatorModifier.swift
@@ -1,0 +1,32 @@
+//
+//  LoadingIndicatorModifier.swift
+//  
+//
+//  Created by Alejandro Zielinsky on 2022-11-01.
+//
+
+import Foundation
+
+struct LoadingIndicatorModifier: ViewModifier {
+    let isLoading: Bool
+
+    func body(content: Content) -> some View {
+        if isLoading {
+            content
+                .blur(radius: 3.0)
+                .overlay(
+                    ProgressView(label: {
+                        Text("Loading...")
+                    })
+                )
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func loadingIndicator(_ isLoading: Bool) -> some View {
+        modifier(LoadingIndicatorModifier(isLoading: isLoading))
+    }
+}

--- a/DebugMenu/DebugMenu/Views/DebugMenuView.swift
+++ b/DebugMenu/DebugMenu/Views/DebugMenuView.swift
@@ -31,6 +31,7 @@ public struct DebugMenuView<DataSource>: View where DataSource: DebugMenuDataSou
                     commonOptions()
                 }
             }
+            .allowsHitTesting(!dataSource.isLoading)
             .loadingIndicator(dataSource.isLoading)
             .environmentObject(dataSource)
             .navigationBarTitle(Text(dataSource.navigationTitle), displayMode: .inline)

--- a/DebugMenu/DebugMenu/Views/DebugMenuView.swift
+++ b/DebugMenu/DebugMenu/Views/DebugMenuView.swift
@@ -52,18 +52,6 @@ public struct DebugMenuView<DataSource>: View where DataSource: DebugMenuDataSou
         }
     }
 
-    var loadingIndicator: some View {
-        ZStack {
-            Color.black.opacity(0.3)
-            Color.black.opacity(0.5)
-                .frame(width: 100, height: 100)
-                .cornerRadius(12)
-            ProgressView {
-                Text("Loading...")
-            }
-        }
-    }
-
     @ViewBuilder func viewForAction(_ action: DebugAction) -> some View {
         if let action = action as? DebugToggleAction {
             DebugToggleRow<DataSource>(action: action, toggle: action.$toggle)

--- a/DebugMenu/DebugMenu/Views/DebugMenuView.swift
+++ b/DebugMenu/DebugMenu/Views/DebugMenuView.swift
@@ -61,7 +61,9 @@ public struct DebugMenuView<DataSource>: View where DataSource: DebugMenuDataSou
             DebugHostControllerRow(action: action)
         } else if let action = action as? DebugTextFieldAlertAction {
             DebugTextFieldAlertRow(action: action)
-        } else  {
+        } else if let action = action as? DebugCustomAction {
+            action.rowView
+        } else {
             Text("Unsupported Action")
         }
     }

--- a/DebugMenu/DebugMenu/Views/DebugMenuView.swift
+++ b/DebugMenu/DebugMenu/Views/DebugMenuView.swift
@@ -31,6 +31,7 @@ public struct DebugMenuView<DataSource>: View where DataSource: DebugMenuDataSou
                     commonOptions()
                 }
             }
+            .loadingIndicator(dataSource.isLoading)
             .environmentObject(dataSource)
             .navigationBarTitle(Text(dataSource.navigationTitle), displayMode: .inline)
             .alert(item: $dataSource.debugAlert, content: { alert in
@@ -47,6 +48,18 @@ public struct DebugMenuView<DataSource>: View where DataSource: DebugMenuDataSou
             Text("No debug options set!")
                 .font(.system(size: 20, weight: .semibold))
                 .navigationBarTitle(Text(dataSource.navigationTitle), displayMode: .inline)
+        }
+    }
+
+    var loadingIndicator: some View {
+        ZStack {
+            Color.black.opacity(0.3)
+            Color.black.opacity(0.5)
+                .frame(width: 100, height: 100)
+                .cornerRadius(12)
+            ProgressView {
+                Text("Loading...")
+            }
         }
     }
 

--- a/DebugMenu/DebugMenu/Views/DebugNavigationRow.swift
+++ b/DebugMenu/DebugMenu/Views/DebugNavigationRow.swift
@@ -1,0 +1,21 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alejandro Zielinsky on 2022-10-31.
+//
+
+import SwiftUI
+
+struct DebugNavigationRow<Destination: View>: View {
+
+    let action: DebugNavigationAction<Destination>
+
+    var body: some View {
+        NavigationLink {
+            action.destination
+        } label: {
+            Text(action.title)
+        }
+    }
+}

--- a/DebugMenu/DebugMenu/Views/DebugToggleRow.swift
+++ b/DebugMenu/DebugMenu/Views/DebugToggleRow.swift
@@ -8,10 +8,19 @@
 import SwiftUI
 import Combine
 
-struct DebugToggleRow: View {
+struct DebugToggleRow<DataSource>: View where DataSource: DebugMenuDataSource  {
+
     let action: DebugToggleAction
+    @EnvironmentObject var dataSource: DataSource
+    @Binding var toggle: Bool
+
+    // This state is required to force redraw when resetting toggle to default value
+    @State var redraw: Bool = false
 
     var body: some View {
-        Toggle(action.displayTitle, isOn: action.toggle)
+        Toggle(action.displayTitle, isOn: $toggle)
+            .onReceive(action.publisher) { _ in
+                redraw.toggle()
+            }
     }
 }

--- a/DebugMenu/DebugMenu/Wrappers/DebugToggle.swift
+++ b/DebugMenu/DebugMenu/Wrappers/DebugToggle.swift
@@ -77,7 +77,7 @@ public struct DebugToggle: DynamicProperty  {
 
         var value: Bool {
             get {
-                if let key {
+                if let key = key {
                     return store.value(forKey: key) as? Bool ?? storedValue
                 } else {
                     return storedValue
@@ -85,7 +85,7 @@ public struct DebugToggle: DynamicProperty  {
             }
             set {
                 objectWillChange.send()
-                if let key {
+                if let key = key {
                     if let optional = newValue as? AnyOptional, optional.isNil {
                         store.removeObject(forKey: key)
                     } else {

--- a/DebugMenu/DebugMenu/Wrappers/DebugToggle.swift
+++ b/DebugMenu/DebugMenu/Wrappers/DebugToggle.swift
@@ -49,7 +49,7 @@ public struct DebugToggle: DynamicProperty  {
         storage: UserDefaults = .standard
     ) {
         self.defaultValue = defaultValue
-        self.displayTitle = title ?? key.camelCaseToWords().replacingOccurrences(of: "Key", with: "")
+        self.displayTitle = title ?? key.camelCaseToWords().replacingOccurrences(of: "Key", with: "").trimmingCharacters(in: .whitespaces)
         self.publisher = PassthroughSubject<Bool, Never>()
         self.storage = Storage(defaultValue, key: key, storage: storage)
     }

--- a/DebugMenu/DebugMenu/Wrappers/DebugToggle.swift
+++ b/DebugMenu/DebugMenu/Wrappers/DebugToggle.swift
@@ -14,6 +14,7 @@ public struct DebugToggle: DynamicProperty  {
     public let displayTitle: String
     public let defaultValue: Bool
     public var publisher: PassthroughSubject<Bool, Never>
+    public let didSet: ((Bool) -> Void)?
 
     @ObservedObject public private(set) var storage: Storage
 
@@ -23,6 +24,7 @@ public struct DebugToggle: DynamicProperty  {
         }
         nonmutating set {
             storage.value = newValue
+            didSet?(newValue)
             publisher.send(newValue)
         }
     }
@@ -46,22 +48,26 @@ public struct DebugToggle: DynamicProperty  {
         wrappedValue defaultValue: Bool,
         title: String? = nil,
         key: String,
-        storage: UserDefaults = .standard
+        storage: UserDefaults = .standard,
+        didSet: ((Bool) -> Void)? = nil
     ) {
         self.defaultValue = defaultValue
         self.displayTitle = title ?? key.camelCaseToWords().replacingOccurrences(of: "Key", with: "").trimmingCharacters(in: .whitespaces)
         self.publisher = PassthroughSubject<Bool, Never>()
         self.storage = Storage(defaultValue, key: key, storage: storage)
+        self.didSet = didSet
     }
 
     public init(
         wrappedValue defaultValue: Bool,
-        title: String
+        title: String,
+        didSet: ((Bool) -> Void)? = nil
     ) {
         self.defaultValue = defaultValue
         self.displayTitle = title
         self.publisher = PassthroughSubject<Bool, Never>()
         self.storage = Storage(defaultValue)
+        self.didSet = didSet
     }
 
     final public class Storage: NSObject, ObservableObject {

--- a/DebugMenu/DebugMenuExample.xcodeproj/project.pbxproj
+++ b/DebugMenu/DebugMenuExample.xcodeproj/project.pbxproj
@@ -63,10 +63,10 @@
 			children = (
 				D23CE6E127557FC8006F6209 /* DebugMenuExampleApp.swift */,
 				D2548FB127DAC43B00D82526 /* SubmenuDataSource.swift */,
+				D2B47D09275944940053D1EA /* DebugMenuStore.swift */,
 				D23CE6E327557FC8006F6209 /* MainView.swift */,
 				D23CE6E527557FCA006F6209 /* Assets.xcassets */,
 				D23CE6E727557FCA006F6209 /* Preview Content */,
-				D2B47D09275944940053D1EA /* DebugMenuStore.swift */,
 				D2548FA427D82DEB00D82526 /* debug-menu-ios */,
 			);
 			path = DebugMenuExample;

--- a/DebugMenu/DebugMenuExample/DebugMenuStore.swift
+++ b/DebugMenu/DebugMenuExample/DebugMenuStore.swift
@@ -30,11 +30,7 @@ public class DebugMenuStore: BaseDebugDataSource {
     }
 
     lazy var toggleSection: DebugSection = {
-        let debugForceFooAction = DebugToggleAction(title: $debugForceFoo.displayTitle, toggle: Binding(get: { self.debugForceFoo }, set: { self.debugForceFoo = $0 }))
-        let showFoosAction = DebugToggleAction(title: $showAllFoos.displayTitle, toggle: Binding(get: { self.showAllFoos }, set: { self.showAllFoos = $0 }))
-        let inMemoryAction = DebugToggleAction(title: $inMemoryFlag.displayTitle, toggle: Binding(get: { self.inMemoryFlag }, set: { self.inMemoryFlag = $0 }))
-
-        return DebugSection(title: "Toggles", actions: [debugForceFooAction, showFoosAction, inMemoryAction])
+        DebugSection(title: "Toggles", actions: [$debugForceFoo.action, $showAllFoos.action, $inMemoryFlag.action])
     }()
 
     lazy var buttonSection: DebugSection = {

--- a/DebugMenu/DebugMenuExample/DebugMenuStore.swift
+++ b/DebugMenu/DebugMenuExample/DebugMenuStore.swift
@@ -13,7 +13,7 @@ import switchcraft
 
 public class DebugMenuStore: BaseDebugDataSource {
     
-    @DebugToggle(key: "debugForceFooKey") var debugForceFoo = false
+    @DebugToggle(key: "debugForceFooKey", didSet: debugForceFooSet) var debugForceFoo = false
     @DebugToggle(title: "Show All Foos", key: "showFoosKey") var showAllFoos = false
     @DebugToggle(title: "In Memory Flag") var inMemoryFlag = false
 
@@ -27,6 +27,11 @@ public class DebugMenuStore: BaseDebugDataSource {
     init() {
         super.init()
         self.addSections([toggleSection, buttonSection, alertSection])
+    }
+
+    // Trigger additional functionality on toggle
+    private static func debugForceFooSet(value: Bool) {
+        print("DebugForceFoo set to \(value)")
     }
 
     lazy var toggleSection: DebugSection = {

--- a/DebugMenu/DebugMenuExample/DebugMenuStore.swift
+++ b/DebugMenu/DebugMenuExample/DebugMenuStore.swift
@@ -24,7 +24,7 @@ public class DebugMenuStore: BaseDebugDataSource {
 
     let config = DebugMenuAccessConfig(passwordSHA256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", longPressDuration: 2.0)
     
-    init() {
+    private init() {
         super.init()
         self.addSections([toggleSection, buttonSection, alertSection])
     }

--- a/DebugMenu/DebugMenuExample/DebugMenuStore.swift
+++ b/DebugMenu/DebugMenuExample/DebugMenuStore.swift
@@ -76,8 +76,10 @@ public class DebugMenuStore: BaseDebugDataSource {
                 action: { code in
                     guard let code = code, !code.isEmpty else { return }
                     //Simulate Network Call
+                    self.isLoading = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
                         //Show Result Alert
+                        self?.isLoading = false
                         self?.debugAlert = DebugAlert(title: "Invalid Code", message: "\(code) is invalid!")
                     }
                 }

--- a/DebugMenu/DebugMenuExample/DebugMenuStore.swift
+++ b/DebugMenu/DebugMenuExample/DebugMenuStore.swift
@@ -56,7 +56,11 @@ public class DebugMenuStore: BaseDebugDataSource {
             Switchcraft.shared.display(from: host)
         }
 
-        return DebugSection(title: "Alerts", actions: [testAlert, testNumericAlert, hostAction])
+        let navigateAction = DebugNavigationAction(title: "SwiftUI View") {
+            Text("Hi")
+        }
+
+        return DebugSection(title: "Alerts", actions: [testAlert, testNumericAlert, hostAction, navigateAction])
     }()
 
     lazy var testAlert: DebugTextFieldAlertAction = {

--- a/DebugMenu/DebugMenuExample/DebugMenuStore.swift
+++ b/DebugMenu/DebugMenuExample/DebugMenuStore.swift
@@ -5,7 +5,6 @@
 //  Created by Alejandro Zielinsky on 2021-12-02.
 //
 
-import Foundation
 import DebugMenu
 import SwiftUI
 import Combine

--- a/DebugMenu/DebugMenuExample/MainView.swift
+++ b/DebugMenu/DebugMenuExample/MainView.swift
@@ -23,7 +23,6 @@ struct MainView: View {
                 }
                 Text("Debug Hidden Entry")
                     .debugMenuToggle(
-                        dataSource: debugMenu,
                         config: debugMenu.config,
                         isVisible: $debugMenu.isVisible,
                         forceShow: $debugMenu.forceShow

--- a/DebugMenu/DebugMenuExample/MainView.swift
+++ b/DebugMenu/DebugMenuExample/MainView.swift
@@ -10,7 +10,7 @@ import DebugMenu
 
 struct MainView: View {
 
-    @ObservedObject var debugMenu = DebugMenuStore.shared
+    @StateObject var debugMenu = DebugMenuStore.shared
 
     var body: some View {
         NavigationView {


### PR DESCRIPTION
This PR fixes issues with State resetting on iOS 16.0+, introduces some optimization and greatly reduces the verbosity of setting up the data source. Something in SwiftUI 4 changed the behaviour of when a Bindings getter gets called causing issues with the entire setup of this Debug library. This PR addresses the issue by reconfiguring how we setup the action model/bindings and receive published changes at the view level.

This PR also optimizes view refreshing performance by removing AnyView type erasure and fixes an issue where resetting to defaultValue wasn't working correctly.

### Old verbose way of setting up a Toggle section
``` Swift
let debugForceFooAction = DebugToggleAction(title: $debugForceFoo.displayTitle, toggle: Binding(get: { self.debugForceFoo }, set: { self.debugForceFoo = $0 }))
let showFoosAction = DebugToggleAction(title: $showAllFoos.displayTitle, toggle: Binding(get: { self.showAllFoos }, set: { self.showAllFoos = $0 }))
let inMemoryAction = DebugToggleAction(title: $inMemoryFlag.displayTitle, toggle: Binding(get: { self.inMemoryFlag }, set: { self.inMemoryFlag = $0 }))

return DebugSection(title: "Toggles", actions: [debugForceFooAction, showFoosAction, inMemoryAction])
```
### New way - directly getting action from property wrapper:
``` Swift 
DebugSection(title: "Toggles", actions: [$debugForceFoo.action, $showAllFoos.action, $inMemoryFlag.action])
```

#### Additional new features
- @DebugToggle can be passed in a didSet block to trigger additional functionality on set. 
- isLoading state added to DebugMenu 

### Broken Behaviour  iOS 16.0

https://user-images.githubusercontent.com/17748596/199081718-aa25a40c-6ad7-445e-8b21-5eaa408379c9.MP4

### Fixed Behaviour  iOS 16.0

https://user-images.githubusercontent.com/17748596/199081790-98922fc7-9734-4a61-97fc-79e8a5809061.MP4


