### PR TITLE
added confirmation dialog

### DIFF
--- a/DebugMenu/DebugMenu/Actions/DebugButtonAction.swift
+++ b/DebugMenu/DebugMenu/Actions/DebugButtonAction.swift
@@ -7,10 +7,12 @@
 
 public struct DebugButtonAction: DebugAction {
     let title: String
+    let confirmationMessage: String?
     let action: () -> Void
     
-    public init(title: String, action: @escaping () -> Void) {
+    public init(title: String, confirmationMessage: String? = nil, action: @escaping () -> Void) {
         self.title = title
+        self.confirmationMessage = confirmationMessage
         self.action = action
     }
 }

--- a/DebugMenu/DebugMenu/Views/DebugButtonRow.swift
+++ b/DebugMenu/DebugMenu/Views/DebugButtonRow.swift
@@ -8,10 +8,24 @@
 import SwiftUI
 
 struct DebugButtonRow: View {
+    @State var showConfirmation: Bool = false
     let action: DebugButtonAction
 
     var body: some View {
-        Button(action.title, action: action.action)
-            .foregroundColor(.blue)
+        if let confirmationMessage = action.confirmationMessage {
+            Button(action.title) {
+                showConfirmation = true
+            }
+            .alert("", isPresented: $showConfirmation) {
+                Button("Ok", role: .destructive) {
+                    action.action()
+                }
+            } message: {
+                Text(confirmationMessage)
+            }
+        } else {
+            Button(action.title, action: action.action)
+                .foregroundColor(.blue)
+        }
     }
 }


### PR DESCRIPTION
It would be nice to have an optional confirmation dialog for a `DebugButtonAction` in case the action is somewhat sensitive/ destructive.

This PR adds an optional String parameter for a confirmation message and shows a confirmation dialog if provided.